### PR TITLE
Explicitly set platform encoding, and DRY in test code.

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ The [existing syslog appender for Logback][logback-syslog-appender] only
 provides the ability to send messages via UDP. Using syslog-java-client allows us to
 send messages via TCP and optionally to encrypt them by sending over TCP with
 TLS. This library also take care of adding message length as per RFC-5424 so log lines containing
-new lines works as well correctly
+new lines work correctly.
 
 ### How?
 

--- a/pom.xml
+++ b/pom.xml
@@ -8,6 +8,10 @@
     <artifactId>syslogappender</artifactId>
     <version>1.0-SNAPSHOT</version>
 
+    <properties>
+        <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+    </properties>
+
     <dependencies>
         <dependency>
             <groupId>com.cloudbees</groupId>
@@ -32,8 +36,6 @@
             <version>4.12</version>
             <scope>test</scope>
         </dependency>
-
-
     </dependencies>
 
     <build>

--- a/src/test/java/org/paggarwal/syslogappender/SyslogAppenderTest.java
+++ b/src/test/java/org/paggarwal/syslogappender/SyslogAppenderTest.java
@@ -39,9 +39,10 @@ public class SyslogAppenderTest {
     final SSLTCPNetSyslogServerConfig ssltcpNetSyslogServerConfig = new SSLTCPNetSyslogServerConfig();
     ssltcpNetSyslogServerConfig.setPort(45554);
     ssltcpNetSyslogServerConfig.addEventHandler(new PrintStreamSyslogServerEventHandler(ps));
-    ssltcpNetSyslogServerConfig.setKeyStore(this.getClass().getClassLoader().getResource("test-keystore.jks").getFile());
+    final String keyStore = this.getClass().getClassLoader().getResource("test-keystore.jks").getFile();
+    ssltcpNetSyslogServerConfig.setKeyStore(keyStore);
     ssltcpNetSyslogServerConfig.setKeyStorePassword("password");
-    ssltcpNetSyslogServerConfig.setTrustStore(this.getClass().getClassLoader().getResource("test-keystore.jks").getFile());
+    ssltcpNetSyslogServerConfig.setTrustStore(keyStore);
     ssltcpNetSyslogServerConfig.setTrustStorePassword("password");
 
     SyslogServer.createThreadedInstance("testTcp", tcpNetSyslogServerConfig);


### PR DESCRIPTION
Also Findbugs complains about:

```
Inconsistent synchronization of org.paggarwal.syslogappender.SyslogAppender.syslogMessageSender; locked 50% of time [org.paggarwal.syslogappender.SyslogAppender, org.paggarwal.syslogappender.SyslogAppender] Unsynchronized access at SyslogAppender.java:[line 32]Synchronized access at SyslogAppender.java:[line 43] IS2_INCONSISTENT_SYNC
```
